### PR TITLE
Fixes github actions cherry-pick

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ EOF
   git config --global --add safe.directory /github/workspace
 }
 
+git_setup
+
 git_cmd() {
   if [[ "${DRY_RUN:-false}" == "true" ]]; then
     echo $@
@@ -34,7 +36,6 @@ fi
 
 PR_TITLE=$(git log -1 --format="%s" $GITHUB_SHA)
 
-git_setup
 git_cmd git remote update
 git_cmd git fetch --all
 git_cmd git checkout -b "${PR_BRANCH}" origin/"${INPUT_PR_BRANCH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ EOF
 
   git config --global user.email "$GITBOT_EMAIL"
   git config --global user.name "$GITHUB_ACTOR"
+  git config --global --add safe.directory /github/workspace
 }
 
 git_cmd() {


### PR DESCRIPTION
## What
* Trusts the `.github/workspace` (especially if this action is triggered when a PR is merged)
* Before running any other github command, for example `git log` to extract the PR title, we need to have called this setup. Therefore it moves the `git_setup` step to the top

## Why
The action has started to fail because git corrected a vulnerability https://github.com/actions/checkout/issues/760 and everything running in docker inside a machine (this action included) with fail with the following:

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:
```